### PR TITLE
fix missing dots

### DIFF
--- a/cachetable.go
+++ b/cachetable.go
@@ -327,5 +327,5 @@ func (table *CacheTable) log(v ...interface{}) {
 		return
 	}
 
-	table.logger.Println(v)
+	table.logger.Println(v...)
 }


### PR DESCRIPTION
Package Testing of go 1.11 is more strict about arguments checking to print-like functions. We will get the error bellow if we left args without dots.
```bash
go test -v
# github.com/muesli/cache2go
./cachetable.go:330: missing ... in args forwarded to print-like function
FAIL    github.com/muesli/cache2go [build failed]
```
OS version:
manjaro 18.0.0-rc
go 1.11.1