### PR TITLE
could not visit CacheItem.Data in AboutToExpireCallback

### DIFF
--- a/cache_test.go
+++ b/cache_test.go
@@ -314,7 +314,7 @@ func TestCallbacks(t *testing.T) {
 
 	// add an item to the cache and setup its AboutToExpire handler
 	i := table.Add(k, 500*time.Millisecond, v)
-	i.SetAboutToExpireCallback(func(key interface{}) {
+	i.SetAboutToExpireCallback(func(key *CacheItem) {
 		m.Lock()
 		expired = true
 		m.Unlock()

--- a/cacheitem.go
+++ b/cacheitem.go
@@ -32,7 +32,7 @@ type CacheItem struct {
 	accessCount int64
 
 	// Callback method triggered right before removing the item from the cache
-	aboutToExpire func(key interface{})
+	aboutToExpire func(item *CacheItem)
 }
 
 // NewCacheItem returns a newly created CacheItem.
@@ -101,7 +101,7 @@ func (item *CacheItem) Data() interface{} {
 
 // SetAboutToExpireCallback configures a callback, which will be called right
 // before the item is about to be removed from the cache.
-func (item *CacheItem) SetAboutToExpireCallback(f func(interface{})) {
+func (item *CacheItem) SetAboutToExpireCallback(f func(*CacheItem)) {
 	item.Lock()
 	defer item.Unlock()
 	item.aboutToExpire = f

--- a/cachetable.go
+++ b/cachetable.go
@@ -190,7 +190,7 @@ func (table *CacheTable) deleteInternal(key interface{}) (*CacheItem, error) {
 	r.RLock()
 	defer r.RUnlock()
 	if r.aboutToExpire != nil {
-		r.aboutToExpire(key)
+		r.aboutToExpire(r)
 	}
 
 	table.Lock()


### PR DESCRIPTION
AboutToExipreCallback arg is key interface{}, if i try get value by table.Value(key)

because AboutToExipreCallback have table.Lock()

and table.Value() have table.RLock()

so, dead locked.